### PR TITLE
Added DecodeAbort to stop reading from tshark stdout and kill the process

### DIFF
--- a/goshark.go
+++ b/goshark.go
@@ -62,6 +62,15 @@ func (d *Decoder) DecodeStart(file string) (err error) {
 	return
 }
 
+// DecodeAbort aborts the ongoing reading and kills tshark process
+func (d *Decoder) DecodeAbort() error {
+	if err := d.cmd.Process.Kill(); err != nil {
+		log.Println("cmd.Process kill fail:", err)
+		return err
+	}
+	return nil
+}
+
 //DecodeEnd Close decoding
 func (d *Decoder) DecodeEnd() error {
 	if err := d.cmd.Wait(); err != nil {


### PR DESCRIPTION
Currently it is not possible to stop reading the output in the middle by breaking out from the reading loop. The processes halt as tshark is still up. A process kill command is sent via DecodeAbort that kills tshark process and allows the program to break out of the loop without halting tshark.
